### PR TITLE
Fix bugs found during code audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Quarkus Chappie is a **dev-mode only** Quarkus extension that adds AI-powered assistance to the Quarkus developer experience. It provides exception help, code generation, documentation search (RAG), and chat — all accessible through the Quarkus Dev UI. Nothing is added to production builds.
+
+The extension spawns a separate `chappie-server` process (downloaded as a JAR from Maven) that handles LLM interactions. The server supports OpenAI, Anthropic, Gemini, WatsonX, and Ollama providers.
+
+## Build Commands
+
+```bash
+# Full build
+mvn clean install
+
+# Fast build (skip tests and docs)
+mvn clean install -DskipTests -Ddocs.skip
+
+# Build a single module
+mvn clean install -pl runtime-dev
+
+# Run integration tests (requires Docker)
+mvn clean install -DskipITs=false
+
+# Run the sample app (then configure provider in Dev UI)
+cd sample && mvn quarkus:dev
+```
+
+There are no linters or formatters configured.
+
+**Note on profiles:** Both `docs` and `it` profiles auto-activate when `performRelease != true`. Integration tests have `skipITs=true` by default, so pass `-DskipITs=false` to run them.
+
+## Module Structure
+
+| Module | Artifact | Purpose |
+|--------|----------|---------|
+| `runtime/` | `quarkus-chappie` | Extension manifest only — no Java code. Declares capability `io.quarkus.assistant`. |
+| `runtime-dev/` | `quarkus-chappie-dev` | Dev-mode runtime: server process management, HTTP client to chappie-server, Dev UI JSON-RPC backend, JSON schema generation. Conditionally loaded only in dev mode. |
+| `deployment/` | `quarkus-chappie-deployment` | Build-time processors: DevServices (pgvector container), Dev UI pages, exception handling, workspace actions (JavaDoc/tests/explain/TODO). |
+| `sample/` | — | Test application with simulated exceptions at `/nullpointer`, `/arithmetic`, etc. |
+| `integration-tests/` | — | Integration tests (skipped by default, enable with `-DskipITs=false`). |
+| `docs/` | — | Extension documentation. Skip with `-Ddocs.skip`. |
+
+## Architecture
+
+### Quarkus Extension Pattern
+
+The extension uses standard Quarkus extension conventions:
+
+- **`@BuildSteps(onlyIf = IsLocalDevelopment.class)`** — All processors are guarded to run only in local dev mode
+- **`ChappieRecorder`** — `@Record(RUNTIME_INIT)` recorder that creates `ChappieServerManager` and maps RAG datasource config
+- **Build items** for inter-processor communication: `LastExceptionBuildItem`, `LastSolutionBuildItem`, `BroadcastsBuildItem`, `ExtensionVersionBuildItem`
+
+The `Assistant` SPI interface comes from Quarkus core (`quarkus-assistant-deployment-spi` / `quarkus-assistant-runtime-dev`), not from this extension. This extension provides the `ChappieAssistant` implementation.
+
+### Configuration
+
+The config prefix is `quarkus.assistant` (not `quarkus.chappie`). Build-time config at `quarkus.assistant.augmenting.enabled` (default `true`) in `ChappieConfig` — this controls whether the pgvector DevService container starts.
+
+Runtime provider config is managed by `ChappieServerManager` and persisted to `~/.quarkus/chappie/chappie-assistant.properties`, not `application.properties`.
+
+### Key Classes (runtime-dev)
+
+- **`ChappieServerManager`** — Core lifecycle manager. Downloads/installs `chappie-server.jar` from Maven, spawns it as a JVM subprocess, manages port allocation (starting at 4315), handles configuration persistence, streams logs via `SubmissionPublisher`, and subscribes to `McpEvent` stream to forward MCP server URLs to chappie-server.
+- **`ChappieAssistant`** — HTTP client implementing the `Assistant` interface. Communicates with chappie-server via REST at `/api/assist`. Auto-detects caller extensions via stack walking for RAG context.
+- **`ChappieJsonRpcService`** — Dev UI backend. JSON-RPC methods for configuration, chat, and chat history management.
+- **`JsonObjectCreator`** — Generates JSON schemas for expected response types using `jsonschema-generator`. Builds request payloads with system/user messages, variables, and response schemas. Parses responses via `ChappieEnvelope<T>`.
+- **`ChappieEnvelope<T>`** — Generic response wrapper record: `{ niceName, answer }`.
+- **`ChappieRecorder`** — Maps RAG datasource config from DevServices keys (`chappie.rag.*`) to chappie-server keys (`quarkus.datasource.chappie.*`).
+
+### Key Classes (deployment)
+
+- **`ChappieProcessor`** — Main processor. Creates beans, discovers extension version from `quarkus-extension.yaml`, sets up console commands, starts pgvector DevService container (`ghcr.io/quarkusio/chappie-ingestion-quarkus:<version>`).
+- **`ChappieDevUIProcessor`** — Registers Dev UI pages (Configure, Chat), JSON-RPC service, and MCP search action (`searchDocs`).
+- **`ExceptionDevUIProcessor`** — Exception help feature: reactive exception broadcasting via `BroadcastProcessor`, "Get help with this" error page link, AI-powered fix suggestions with diff, apply-fix capability.
+- **`BuiltInActionsProcessor`** — Workspace actions: Add JavaDoc, Generate Test, Explain, Complete TODO. Each uses prompt templates from corresponding `*Prompts` classes.
+
+### RAG Config Flow
+
+DevServices → Recorder → ChappieServerManager → chappie-server subprocess:
+1. `startPgvectorDevService()` produces config keys like `chappie.rag.jdbc.url`
+2. `ChappieRecorder` maps these to `quarkus.datasource.chappie.*` keys
+3. `ChappieServerManager.getChappieServerArguments()` passes them as `-D` JVM args to the subprocess
+
+### DevServices
+
+The `startPgvectorDevService()` BuildStep in `ChappieProcessor` launches a PostgreSQL container with pre-baked RAG embeddings using TestContainers. The container image tag matches the Quarkus version, falling back to "latest" for SNAPSHOT versions.
+
+### Dev UI Integration
+
+Web components (in `runtime-dev/src/main/resources/dev-ui/`):
+- `qwc-chappie-configure.js` — AI provider settings
+- `qwc-chappie-chat.js` — Chat interface
+- `qwc-chappie-exception.js` — Exception help page
+- `qwc-chappie-init.js` — Headless initialization
+
+## Cross-Project Development
+
+To test changes to the chappie-server with this extension:
+
+1. Clone and build chappie-server: `mvn clean install -Dquarkus.profile=chappie`
+2. In `runtime-dev/pom.xml`, change `<chappie-server.version>` to `999-SNAPSHOT`
+3. Rebuild this extension after each server change
+
+## Key Dependency
+
+The `runtime-dev/pom.xml` uses `maven-dependency-plugin` to copy the `chappie-server.jar` into `target/classes/bin/` at build time. The version is controlled by the `<chappie-server.version>` property (currently `1.1.9`).

--- a/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
@@ -253,8 +253,8 @@ public class ChappieProcessor {
             if (version.equals("latest")) {
                 throw new RuntimeException("Could not start Chappie RAG Dev Service using Quarkus version latest", t);
             }
-            LOG.warnf("Could not start Chappie RAG Dev Service using Quarkus version %s. Falling back to latest version",
-                    version);
+            LOG.warnf(t, "Could not start Chappie RAG Dev Service using image %s. Falling back to latest version",
+                    getImage(version));
             return createContainer("latest");
         }
     }

--- a/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieAssistant.java
+++ b/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieAssistant.java
@@ -21,6 +21,8 @@ import io.quarkus.logging.Log;
 
 public class ChappieAssistant implements Assistant {
 
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
     private String baseUrl = null;
     private String memoryId = null;
     private String title = null;
@@ -138,8 +140,11 @@ public class ChappieAssistant implements Assistant {
                     .header("Accept", "application/json")
                     .build();
 
-            HttpClient client = HttpClient.newHttpClient();
-            client.sendAsync(r, HttpResponse.BodyHandlers.ofString());
+            HTTP_CLIENT.sendAsync(r, HttpResponse.BodyHandlers.ofString())
+                    .exceptionally(ex -> {
+                        Log.error("Failed to delete chat " + memoryId, ex);
+                        return null;
+                    });
         }
     }
 
@@ -150,7 +155,7 @@ public class ChappieAssistant implements Assistant {
             if (maxResults != null) {
                 params.put("maxResults", maxResults);
             }
-            if (extension == null) {
+            if (extension != null) {
                 params.put("extension", extension);
             }
             String jsonPayload = JsonObjectCreator.toJsonString(params);
@@ -200,9 +205,7 @@ public class ChappieAssistant implements Assistant {
     }
 
     private <T> CompletionStage<T> getAny(HttpRequest request, Class<T> responseType, boolean unwrap) {
-        HttpClient client = HttpClient.newHttpClient();
-
-        return (CompletableFuture<T>) client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return (CompletableFuture<T>) HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply((response) -> {
                     int status = response.statusCode();
                     if (status == 200) {
@@ -225,16 +228,13 @@ public class ChappieAssistant implements Assistant {
                             return Map.of(this.memoryId, envelope);
                         }
                     } else {
-                        // TODO: Can we get more details ?
-                        throw new RuntimeException("Failed with HTTP error code : " + status);
+                        throw new RuntimeException("Failed with HTTP " + status + ": " + response.body());
                     }
                 });
     }
 
     private CompletionStage<Map> getObject(HttpRequest request) {
-        HttpClient client = HttpClient.newHttpClient();
-
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     int status = response.statusCode();
                     if (status == 200) {
@@ -246,15 +246,13 @@ public class ChappieAssistant implements Assistant {
                     } else if (status == 204) {
                         return Map.of();
                     } else {
-                        throw new RuntimeException("Failed: HTTP error code : " + status);
+                        throw new RuntimeException("Failed with HTTP " + status + ": " + response.body());
                     }
                 });
     }
 
     private CompletionStage<List<Map>> getArray(HttpRequest request) {
-        HttpClient client = HttpClient.newHttpClient();
-
-        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        return HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     int status = response.statusCode();
                     switch (status) {
@@ -267,7 +265,7 @@ public class ChappieAssistant implements Assistant {
                         case 204:
                             return List.of();
                         default:
-                            throw new RuntimeException("Failed: HTTP error code : " + status);
+                            throw new RuntimeException("Failed with HTTP " + status + ": " + response.body());
                     }
                 });
     }

--- a/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieHotReplacementSetup.java
+++ b/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieHotReplacementSetup.java
@@ -27,6 +27,9 @@ public class ChappieHotReplacementSetup implements HotReplacementSetup {
 
     @Override
     public void close() {
+        if (currentProcess == null) {
+            return;
+        }
         try {
             currentProcess.destroy();
         } catch (Exception e) {

--- a/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieServerManager.java
+++ b/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieServerManager.java
@@ -194,11 +194,13 @@ public class ChappieServerManager {
     public Properties loadConfiguration(String name) {
         Properties fullProps = new Properties();
 
-        if (Files.exists(configFile)) {
-            try (InputStream in = Files.newInputStream(configFile)) {
-                fullProps.load(in);
-            } catch (IOException ex) {
-                ex.printStackTrace();
+        synchronized (configLock) {
+            if (Files.exists(configFile)) {
+                try (InputStream in = Files.newInputStream(configFile)) {
+                    fullProps.load(in);
+                } catch (IOException ex) {
+                    LOG.error("Failed to load configuration", ex);
+                }
             }
         }
 
@@ -257,26 +259,29 @@ public class ChappieServerManager {
     private Properties readFullConfiguration() {
         Properties existingProps = new Properties();
 
-        // Load existing configuration if present
-        if (Files.exists(configFile)) {
-            try (InputStream in = Files.newInputStream(configFile)) {
-                existingProps.load(in);
-            } catch (IOException ex) {
-                ex.printStackTrace();
+        synchronized (configLock) {
+            if (Files.exists(configFile)) {
+                try (InputStream in = Files.newInputStream(configFile)) {
+                    existingProps.load(in);
+                } catch (IOException ex) {
+                    LOG.error("Failed to read configuration", ex);
+                }
             }
         }
         return existingProps;
     }
 
     private boolean saveFullConfiguration(Properties p, Runnable postAction) {
-        try (OutputStream out = Files.newOutputStream(configFile)) {
-            p.store(out, "Chappie Configuration");
-            postAction.run();
-            return true;
-        } catch (IOException ex) {
-            ex.printStackTrace();
-            return false;
+        synchronized (configLock) {
+            try (OutputStream out = Files.newOutputStream(configFile)) {
+                p.store(out, "Chappie Configuration");
+            } catch (IOException ex) {
+                LOG.error("Failed to save configuration", ex);
+                return false;
+            }
         }
+        postAction.run();
+        return true;
     }
 
     public String getConfiguredProviderName() {
@@ -382,21 +387,17 @@ public class ChappieServerManager {
     private void startStreamingLog() {
         logStreaming = true;
         this.logExecutor = Executors.newSingleThreadScheduledExecutor();
-        logExecutor.scheduleWithFixedDelay(() -> {
+        logTask = logExecutor.scheduleWithFixedDelay(() -> {
             try (BufferedReader reader = new BufferedReader(new FileReader(logFile.toFile()))) {
                 String line;
-                while (logStreaming) {
-                    if ((line = reader.readLine()) != null) {
-                        logPublisher.submit(line);
-                    }
+                while (logStreaming && (line = reader.readLine()) != null) {
+                    logPublisher.submit(line);
                 }
             } catch (Exception e) {
                 logPublisher.closeExceptionally(e);
                 if (logExecutor != null && !logExecutor.isShutdown()) {
                     logExecutor.shutdownNow();
                 }
-            } finally {
-                //publisher.close();
             }
         }, 0, 200, TimeUnit.MILLISECONDS);
     }
@@ -695,6 +696,7 @@ public class ChappieServerManager {
                 lowerArg.contains("credential");
     }
 
+    private final Object configLock = new Object();
     private final Path configDir = Paths.get(System.getProperty("user.home"), ".quarkus", "chappie");
     private final Path configFile = configDir.resolve("chappie-assistant.properties");
     private final Path logFile = configDir.resolve("chappie-assistant.log");


### PR DESCRIPTION
Logic bug, NPE, CPU spin, concurrency

- Fix inverted condition in searchDocs() — extension filter was never sent to server
- Add null guard in ChappieHotReplacementSetup.close() to prevent NPE on shutdown
- Fix CPU spin in log streaming: remove inner while-loop, assign logTask for cancellation
- Replace ex.printStackTrace() with LOG.error() in 3 config methods
- Use shared static HttpClient instead of creating new one per request
- Add .exceptionally() handler to fire-and-forget deleteChat() call
- Synchronize config file reads/writes with configLock to prevent corruption
- Include response body in HTTP error exception messages for debugging
- Log actual image name and error in DevService fallback warning