### PR TITLE
Use generic pgvector image instead of version-specific chappie-ingestion image

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
@@ -23,7 +23,6 @@ import io.quarkiverse.chappie.runtime.dev.ChappieRecorder;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.assistant.deployment.spi.AssistantConsoleBuildItem;
 import io.quarkus.assistant.runtime.dev.Assistant;
-import io.quarkus.builder.Version;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -228,39 +227,16 @@ public class ChappieProcessor {
         return null;
     }
 
-    private StartableContainer<? extends PostgreSQLContainer<?>> createContainer() {
-        String version = Version.getVersion();
+    private static final String PGVECTOR_IMAGE = "pgvector/pgvector:pg17";
 
-        if (version.equalsIgnoreCase("999-SNAPSHOT")) {
-            version = "latest";
-        }
+    private StartableContainer<PostgreSQLContainer<?>> createContainer() {
+        DockerImageName img = DockerImageName.parse(PGVECTOR_IMAGE)
+                .asCompatibleSubstituteFor("postgres");
 
-        return createContainer(version);
-    }
-
-    private StartableContainer<PostgreSQLContainer<?>> createContainer(String version) {
-        try {
-            String image = getImage(version);
-
-            DockerImageName img = DockerImageName.parse(image)
-                    .asCompatibleSubstituteFor("postgres");
-
-            return new StartableContainer<>(new PostgreSQLContainer<>(img)
-                    .withDatabaseName("postgres")
-                    .withUsername("postgres")
-                    .withPassword("postgres"));
-        } catch (Throwable t) {
-            if (version.equals("latest")) {
-                throw new RuntimeException("Could not start Chappie RAG Dev Service using Quarkus version latest", t);
-            }
-            LOG.warnf("Could not start Chappie RAG Dev Service using Quarkus version %s. Falling back to latest version",
-                    version);
-            return createContainer("latest");
-        }
-    }
-
-    private String getImage(String version) {
-        return "ghcr.io/quarkusio/chappie-ingestion-quarkus:" + version;
+        return new StartableContainer<>(new PostgreSQLContainer<>(img)
+                .withDatabaseName("postgres")
+                .withUsername("postgres")
+                .withPassword("postgres"));
     }
 
     private void printResponse(CompletionStage response, Vertx vertx, long timer) {


### PR DESCRIPTION
The RAG documentation data is now loaded from SQL fragments at runtime rather than being baked into the Docker image. This means the Dev Service container no longer needs a version-specific image with a pre-built vector store — a generic pgvector is sufficient.

This removes the version-specific image resolution and fallback logic from `ChappieProcessor`, replacing it with a single `pgvector/pgvector:pg17` constant.

Part of the broader RAG migration:
- [quarkus-documentation-rag](https://github.com/quarkusio/quarkus-documentation-rag) — Maven plugin that generates SQL from AsciiDoc guides
- [chappie-server#40](https://github.com/chappie-bot/chappie-server/pull/40) — Corresponding chappie-server changes
- [quarkus-agent-mcp#136](https://github.com/quarkusio/quarkus-agent-mcp/pull/136) — Corresponding agent-mcp changes