### PR TITLE
Switch DevService to plain pgvector for RAG SQL fragment loading

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
@@ -70,13 +70,11 @@ public class ChappieProcessor {
 
         String devmcpPath = nonApplicationRootPathBuildItem.resolvePath(DEVMCP);
 
-        if (resolvedQuarkusVersion == null) {
-            resolvedQuarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
-        }
+        String quarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
 
         RuntimeValue<SubmissionPublisher<String>> chappieLog = recorder.createChappieServerManager(beanContainer.getValue(),
                 assistant,
-                extensionVersionBuildItem.getVersion(), resolvedQuarkusVersion, devmcpPath);
+                extensionVersionBuildItem.getVersion(), quarkusVersion, devmcpPath);
 
         DevConsoleManager.register("chappie.setBaseUrl", (t) -> {
             String baseUrl = null;
@@ -206,8 +204,6 @@ public class ChappieProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    private String resolvedQuarkusVersion;
-
     @BuildStep
     public DevServicesResultBuildItem startPgvectorDevService(LaunchModeBuildItem launchMode,
             DockerStatusBuildItem dockerStatus, ChappieConfig cfg,
@@ -216,11 +212,11 @@ public class ChappieProcessor {
         if (launchMode.getLaunchMode().isDevOrTest()
                 && cfg.augmenting().enabled()
                 && dockerStatus.isContainerRuntimeAvailable()) {
-            resolvedQuarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
+            String quarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
             return DevServicesResultBuildItem.owned()
                     .name("Assistant_Store")
                     .serviceConfig(cfg.augmenting())
-                    .startable(this::createContainer)
+                    .startable(() -> createContainer(quarkusVersion))
                     .postStartHook(
                             c -> LOG.infof("Chappie RAG Dev Service started from %s, JDBC=%s", c.getContainer().getImage(),
                                     c.getContainer().getJdbcUrl()))
@@ -265,11 +261,11 @@ public class ChappieProcessor {
         }
     }
 
-    private StartableContainer<? extends PostgreSQLContainer<?>> createContainer() {
-        if (supportsRagSql(resolvedQuarkusVersion)) {
+    private StartableContainer<? extends PostgreSQLContainer<?>> createContainer(String quarkusVersion) {
+        if (supportsRagSql(quarkusVersion)) {
             return createPlainPgvectorContainer();
         }
-        return createLegacyContainer(resolvedQuarkusVersion);
+        return createLegacyContainer(quarkusVersion);
     }
 
     private StartableContainer<PostgreSQLContainer<?>> createPlainPgvectorContainer() {

--- a/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
@@ -204,13 +204,17 @@ public class ChappieProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
+    private String resolvedQuarkusVersion;
+
     @BuildStep
     public DevServicesResultBuildItem startPgvectorDevService(LaunchModeBuildItem launchMode,
-            DockerStatusBuildItem dockerStatus, ChappieConfig cfg) {
+            DockerStatusBuildItem dockerStatus, ChappieConfig cfg,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
 
         if (launchMode.getLaunchMode().isDevOrTest()
                 && cfg.augmenting().enabled()
                 && dockerStatus.isContainerRuntimeAvailable()) {
+            resolvedQuarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
             return DevServicesResultBuildItem.owned()
                     .name("Assistant_Store")
                     .serviceConfig(cfg.augmenting())
@@ -238,8 +242,60 @@ public class ChappieProcessor {
         return null;
     }
 
+    private static boolean supportsRagSql(String version) {
+        if (version == null || version.isBlank() || version.contains("SNAPSHOT")) {
+            return true;
+        }
+        try {
+            String[] parts = version.split("[.\\-]");
+            int major = Integer.parseInt(parts[0]);
+            int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+            if (major > 3 || (major == 3 && minor > 36)) {
+                return true;
+            }
+            if (major == 3 && minor == 36) {
+                int patch = parts.length > 2 ? Integer.parseInt(parts[2]) : 0;
+                return patch >= 1;
+            }
+            return false;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
     private StartableContainer<? extends PostgreSQLContainer<?>> createContainer() {
+        if (supportsRagSql(resolvedQuarkusVersion)) {
+            return createPlainPgvectorContainer();
+        }
+        return createLegacyContainer(resolvedQuarkusVersion);
+    }
+
+    private StartableContainer<PostgreSQLContainer<?>> createPlainPgvectorContainer() {
         DockerImageName img = DockerImageName.parse("pgvector/pgvector:pg17")
+                .asCompatibleSubstituteFor("postgres");
+
+        return new StartableContainer<>(new PostgreSQLContainer<>(img)
+                .withDatabaseName("postgres")
+                .withUsername("postgres")
+                .withPassword("postgres"));
+    }
+
+    private StartableContainer<PostgreSQLContainer<?>> createLegacyContainer(String version) {
+        String tag = (version != null) ? version : "latest";
+        try {
+            return createLegacyImage(tag);
+        } catch (Throwable t) {
+            if ("latest".equals(tag)) {
+                throw new RuntimeException("Could not start Chappie RAG Dev Service using image tag " + tag, t);
+            }
+            LOG.warnf("Could not start Chappie RAG Dev Service using Quarkus version %s, falling back to latest", tag);
+            return createLegacyImage("latest");
+        }
+    }
+
+    private StartableContainer<PostgreSQLContainer<?>> createLegacyImage(String tag) {
+        String image = "ghcr.io/quarkusio/chappie-ingestion-quarkus:" + tag;
+        DockerImageName img = DockerImageName.parse(image)
                 .asCompatibleSubstituteFor("postgres");
 
         return new StartableContainer<>(new PostgreSQLContainer<>(img)

--- a/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
@@ -23,7 +23,6 @@ import io.quarkiverse.chappie.runtime.dev.ChappieRecorder;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.assistant.deployment.spi.AssistantConsoleBuildItem;
 import io.quarkus.assistant.runtime.dev.Assistant;
-import io.quarkus.builder.Version;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -229,38 +228,13 @@ public class ChappieProcessor {
     }
 
     private StartableContainer<? extends PostgreSQLContainer<?>> createContainer() {
-        String version = Version.getVersion();
+        DockerImageName img = DockerImageName.parse("pgvector/pgvector:pg17")
+                .asCompatibleSubstituteFor("postgres");
 
-        if (version.equalsIgnoreCase("999-SNAPSHOT")) {
-            version = "latest";
-        }
-
-        return createContainer(version);
-    }
-
-    private StartableContainer<PostgreSQLContainer<?>> createContainer(String version) {
-        try {
-            String image = getImage(version);
-
-            DockerImageName img = DockerImageName.parse(image)
-                    .asCompatibleSubstituteFor("postgres");
-
-            return new StartableContainer<>(new PostgreSQLContainer<>(img)
-                    .withDatabaseName("postgres")
-                    .withUsername("postgres")
-                    .withPassword("postgres"));
-        } catch (Throwable t) {
-            if (version.equals("latest")) {
-                throw new RuntimeException("Could not start Chappie RAG Dev Service using Quarkus version latest", t);
-            }
-            LOG.warnf("Could not start Chappie RAG Dev Service using Quarkus version %s. Falling back to latest version",
-                    version);
-            return createContainer("latest");
-        }
-    }
-
-    private String getImage(String version) {
-        return "ghcr.io/quarkusio/chappie-ingestion-quarkus:" + version;
+        return new StartableContainer<>(new PostgreSQLContainer<>(img)
+                .withDatabaseName("postgres")
+                .withUsername("postgres")
+                .withPassword("postgres"));
     }
 
     private void printResponse(CompletionStage response, Vertx vertx, long timer) {

--- a/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
@@ -70,11 +70,13 @@ public class ChappieProcessor {
 
         String devmcpPath = nonApplicationRootPathBuildItem.resolvePath(DEVMCP);
 
-        String quarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
+        if (resolvedQuarkusVersion == null) {
+            resolvedQuarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
+        }
 
         RuntimeValue<SubmissionPublisher<String>> chappieLog = recorder.createChappieServerManager(beanContainer.getValue(),
                 assistant,
-                extensionVersionBuildItem.getVersion(), quarkusVersion, devmcpPath);
+                extensionVersionBuildItem.getVersion(), resolvedQuarkusVersion, devmcpPath);
 
         DevConsoleManager.register("chappie.setBaseUrl", (t) -> {
             String baseUrl = null;

--- a/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/chappie/deployment/ChappieProcessor.java
@@ -70,9 +70,11 @@ public class ChappieProcessor {
 
         String devmcpPath = nonApplicationRootPathBuildItem.resolvePath(DEVMCP);
 
+        String quarkusVersion = resolveQuarkusVersion(curateOutcomeBuildItem);
+
         RuntimeValue<SubmissionPublisher<String>> chappieLog = recorder.createChappieServerManager(beanContainer.getValue(),
                 assistant,
-                extensionVersionBuildItem.getVersion(), devmcpPath);
+                extensionVersionBuildItem.getVersion(), quarkusVersion, devmcpPath);
 
         DevConsoleManager.register("chappie.setBaseUrl", (t) -> {
             String baseUrl = null;
@@ -223,6 +225,15 @@ public class ChappieProcessor {
                             "chappie.rag.password", c -> c.getContainer().getPassword(),
                             "chappie.rag.active", c -> "false"))
                     .build();
+        }
+        return null;
+    }
+
+    private String resolveQuarkusVersion(CurateOutcomeBuildItem curateOutcome) {
+        for (var dep : curateOutcome.getApplicationModel().getDependencies()) {
+            if ("io.quarkus".equals(dep.getGroupId()) && "quarkus-core".equals(dep.getArtifactId())) {
+                return dep.getVersion();
+            }
         }
         return null;
     }

--- a/runtime-dev/pom.xml
+++ b/runtime-dev/pom.xml
@@ -13,7 +13,7 @@
     <description>Chappie assistant implementation - Dev mode only</description>
 
     <properties>
-        <chappie-server.version>1.1.9</chappie-server.version>
+        <chappie-server.version>1.2.0</chappie-server.version>
     </properties>
 
     <dependencies>

--- a/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieRecorder.java
+++ b/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieRecorder.java
@@ -20,6 +20,7 @@ public class ChappieRecorder {
     public RuntimeValue<SubmissionPublisher<String>> createChappieServerManager(BeanContainer beanContainer,
             ChappieAssistant assistant,
             String chappieServerVersion,
+            String quarkusVersion,
             String devMcpPath) {
         Config config = ConfigProvider.getConfig();
         Map<String, String> chappieRAGProperties = new HashMap<>();
@@ -38,7 +39,8 @@ public class ChappieRecorder {
         }
 
         ChappieServerManager chappieServerManager = beanContainer.beanInstance(ChappieServerManager.class);
-        return new RuntimeValue(chappieServerManager.init(chappieServerVersion, assistant, chappieRAGProperties, devMcpPath));
+        return new RuntimeValue(
+                chappieServerManager.init(chappieServerVersion, quarkusVersion, assistant, chappieRAGProperties, devMcpPath));
     }
 
     void configMap(Config config, Map<String, String> map, String sourceKey, String targetKey) {

--- a/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieServerManager.java
+++ b/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieServerManager.java
@@ -568,6 +568,10 @@ public class ChappieServerManager {
                     }
                 }
                 properties.put("quarkus.datasource.active", "true");
+                properties.put("chappie.rag.quarkus-version",
+                        io.quarkus.builder.Version.getVersion());
+                properties.put("chappie.rag.project-dir",
+                        System.getProperty("user.dir"));
             }
 
             // MCP Settings

--- a/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieServerManager.java
+++ b/runtime-dev/src/main/java/io/quarkiverse/chappie/runtime/dev/ChappieServerManager.java
@@ -56,6 +56,7 @@ public class ChappieServerManager {
 
     private ChappieAssistant assistant;
     private String version;
+    private String quarkusVersion;
     private Map<String, String> chappieRAGProperties;
 
     private String devMcpPath;
@@ -100,10 +101,11 @@ public class ChappieServerManager {
         setCurrentProcess.accept(process);
     }
 
-    public SubmissionPublisher<String> init(String version, ChappieAssistant assistant,
+    public SubmissionPublisher<String> init(String version, String quarkusVersion, ChappieAssistant assistant,
             Map<String, String> chappieRAGProperties, String devMcpPath) {
         this.assistant = assistant;
         this.version = version;
+        this.quarkusVersion = quarkusVersion;
         this.chappieRAGProperties = chappieRAGProperties;
         this.devMcpPath = devMcpPath;
         if (Files.notExists(configDir)) {
@@ -568,8 +570,9 @@ public class ChappieServerManager {
                     }
                 }
                 properties.put("quarkus.datasource.active", "true");
-                properties.put("chappie.rag.quarkus-version",
-                        io.quarkus.builder.Version.getVersion());
+                if (this.quarkusVersion != null) {
+                    properties.put("chappie.rag.quarkus-version", this.quarkusVersion);
+                }
                 properties.put("chappie.rag.project-dir",
                         System.getProperty("user.dir"));
             }


### PR DESCRIPTION
The chappie-server now loads RAG documentation at runtime from the `quarkus-documentation-core-rag` Maven artifact instead of requiring a pre-populated Docker image. This switches the DevService container from `ghcr.io/quarkusio/chappie-ingestion-quarkus:{version}` to a plain `pgvector/pgvector:pg17` and passes the Quarkus version and project directory to chappie-server so it can download the correct RAG artifact and discover Quarkiverse extension docs.

Companion PR: https://github.com/chappie-bot/chappie-server/pull/41